### PR TITLE
Bug : you can't test a variable true-ness after an assignment from a macro

### DIFF
--- a/tests/compiler.js
+++ b/tests/compiler.js
@@ -1154,5 +1154,15 @@
             finish(done);
         });
 
+        it('\'if\' should behaves exactly as javascript\'s if behaves (if after set)', function(done) {
+            equal('{% set a = \'\' %}{% if a %}true{% else %}false{% endif %}', 'false');
+            finish(done);
+        });
+
+        it('\'if\' should behaves exactly as javascript\'s if behaves (if after set=macro)', function(done) {
+            equal('{% macro m(t)%}{{ t }}{% endmacro %}{% set a = m(\'\') %}{% if a %}true{% else %}false{% endif %}', 'false');
+            finish(done);
+        });
+
     });
 })();


### PR DESCRIPTION
Sorry to not include a fix.

the generated code for the **if** of

```
{% set a = macro_that_return_empty_string(...) %}
{% if ( a ) %}
```

is

```
if( runtime.contextOrFrameLookup(context, frame, "a") ) {
```

which return a SafeString **{ 'val':'','length':0 }** instead of **''** (so the **if** gets always **true**)

It works with **{% if ( a != '') %}** because of the toString method on SafeString.

I think the compiler should produce something like : 

```
if( runtime.contextOrFrameLookup(context, frame, "a").val ) {
```
